### PR TITLE
fix bug on delete operation in doubly linked-list

### DIFF
--- a/Chapter04/delete_operation_doubly_linkedlist.py
+++ b/Chapter04/delete_operation_doubly_linkedlist.py
@@ -31,9 +31,9 @@ class DoublyLinkedList:
         if current is None:       #List is empty
             print("List is empty")
         elif current.data == data:   #Item to be deleted is found at starting of list
+            self.head = current.next
             self.head.prev = None 
             node_deleted = True 
-            self.head = current.next
 
         elif self.tail.data == data:   #Item to be deleted is found at the end of list.
             self.tail = self.tail.prev  


### PR DESCRIPTION
In "Chapter04/delete_operation_doubly_linkedlist.py" in case where the item to be deleted is found at starting of the list, there is currently a bug:

```python
    def delete(self, data):
        # Delete a node from the list. 
        current = self.head 
        node_deleted = False 
        if current is None:       #List is empty
            print("List is empty")
        elif current.data == data:   #Item to be deleted is found at starting of list
            self.head.prev = None 
            node_deleted = True 
            self.head = current.next
```
The `self.head.prev = None` line has no effect because it's already `None`. Therefore when `self.head = current.next` line is executed we'll have a head which has a `prev`! 

To fix it all we have to do is move the `self.head = current.next` line to the top so that after the new head is assigned, we set its `prev` to `None`.