### PR TITLE
Chapter06 - Tree - level order traversal bug

### DIFF
--- a/Chapter06/level_order_traversal.py
+++ b/Chapter06/level_order_traversal.py
@@ -26,8 +26,8 @@ def level_order_traversal(root_node):
         list_of_nodes.append(node.data) 
         if node.left_child: 
             traversal_queue.append(node.left_child) 
-            if node.right_child: 
-                traversal_queue.append(node.right_child) 
+        if node.right_child: 
+            traversal_queue.append(node.right_child) 
     return list_of_nodes 
 
 


### PR DESCRIPTION
There is currently a wrong extra indentation in the body of the `level_order_traversal()` function:

```python
def level_order_traversal(root_node): 
    list_of_nodes = [] 
    traversal_queue = deque([root_node]) 
    while len(traversal_queue) > 0:
        node = traversal_queue.popleft() 
        list_of_nodes.append(node.data) 
        if node.left_child: 
            traversal_queue.append(node.left_child) 
            if node.right_child:                           #############
                traversal_queue.append(node.right_child)   #############
    return list_of_nodes 
```
which causes the node's `right_child` not being seen if it doesn't have any `left_child`.

Here is an example:

```python
class Node:
    def __init__(self, data):
        self.data = data
        self.right_child = None
        self.left_child = None

n1 = Node("root node")
n2 = Node("left child node")
n3 = Node("right child node")
n4 = Node("right grandchild node")

n1.left_child = n2
n1.right_child = n3
n2.right_child = n4
```