### PR TITLE
Chapter06/binary_search_tree - fix the case where node is not found.

### DIFF
--- a/Chapter06/binary_search_tree.py
+++ b/Chapter06/binary_search_tree.py
@@ -42,8 +42,8 @@ class Tree:
         parent = None 
         current = self.root_node 
         if current is None: 
-            return (parent, None) 
-        while True: 
+            return (None, None) 
+        while current is not None: 
             if current.data == data: 
                 return (parent, current) 
             elif current.data > data: 
@@ -51,8 +51,8 @@ class Tree:
                 current = current.left_child 
             else: 
                 parent = current 
-                current = current.right_child 
-        return (parent, current) 
+                current = current.right_child
+        return (None, None)
    
 
     def remove(self, data):  


### PR DESCRIPTION
In `Chapter06/binary_search_tree.py`, the current implementation of `get_node_with_parent` has two problems:

1. The last line is unreachable.
2. In case the removing item is not present in the tree, an exception is raised. That's because `current` will eventually be `None` and `None` doesn't have `.data` attribute. So I returned the same `(None, None)` value so that the `.remove()` method terminates.