### PR TITLE
Chapter07 -  enhance min-heap implementation 

### DIFF
--- a/Chapter07/heap.py
+++ b/Chapter07/heap.py
@@ -45,6 +45,7 @@ class MinHeap:
         self.heap[location] = self.heap[self.size]
         self.size -= 1
         self.heap.pop()
+        self.arrange(location)
         self.sink(location)
         return item
       

--- a/Chapter07/heap.py
+++ b/Chapter07/heap.py
@@ -5,8 +5,9 @@ class MinHeap:
 
     def arrange(self, k):
         while k // 2 > 0:
-            if self.heap[k] < self.heap[k//2]:
-                self.heap[k], self.heap[k//2] = self.heap[k//2], self.heap[k]
+            if self.heap[k] > self.heap[k//2]:
+                break
+            self.heap[k], self.heap[k//2] = self.heap[k//2], self.heap[k]
             k //= 2
 
     def insert(self, item):
@@ -17,8 +18,9 @@ class MinHeap:
     def sink(self, k):
         while k * 2 <= self.size:
             mc = self.minchild(k)
-            if self.heap[k] > self.heap[mc]:
-                self.heap[k], self.heap[mc] = self.heap[mc], self.heap[k]
+            if self.heap[k] < self.heap[mc]:
+                break
+            self.heap[k], self.heap[mc] = self.heap[mc], self.heap[k]
             k = mc
 
     def minchild(self, k):


### PR DESCRIPTION
Hi,
I made two changes to the current implementation of min-heap:

1. In both insertion(in `.arrange()` method) and deletion(in `.sink()` method) we can stop iterating as soon as we find out that there is no need to swap the values.
2. In `delete_at_location()` method, we need to compare the newly inserted node with its parent. Here is an example that reveals the bug:

```python
h = MinHeap()
for i in (1, 10, 2, 11, 12, 3, 4):
    h.insert(i)
print(h.heap)
n = h.delete_at_location(5)
print(h.heap)
```
After the deletion the output is `[0, 1, 10, 2, 11, 4, 3]` which is wrong. If we draw this min-heap we could see that index 5(which has the value of 4) is less smaller than index 2(which has the value of 10)

Thanks.