### PR TITLE
Fix the issue in FIFO retrieval in priorityQueueHeap.py

### DIFF
--- a/Chapter07/priorityQueueHeap.py
+++ b/Chapter07/priorityQueueHeap.py
@@ -5,11 +5,12 @@ class PriorityQueueHeap:
 
     def arrange(self, k):
         while k // 2 > 0:
-            if self.heap[k][0] < self.heap[k//2][0]:
-                self.heap[k], self.heap[k//2] = self.heap[k//2], self.heap[k]
+            if self.heap[k][0] >= self.heap[k // 2][0]:
+                break
+            self.heap[k], self.heap[k // 2] = self.heap[k // 2], self.heap[k]
             k //= 2
 
-    def insert(self,priority, item):
+    def insert(self, priority, item):
         self.heap.append((priority, item))
         self.size += 1
         self.arrange(self.size)
@@ -17,14 +18,15 @@ class PriorityQueueHeap:
     def sink(self, k):
         while k * 2 <= self.size:
             mc = self.minchild(k)
-            if self.heap[k][0] > self.heap[mc][0]:
-                self.heap[k], self.heap[mc] = self.heap[mc], self.heap[k]
+            if self.heap[k][0] < self.heap[mc][0]:
+                break
+            self.heap[k], self.heap[mc] = self.heap[mc], self.heap[k]
             k = mc
 
     def minchild(self, k):
         if k * 2 + 1 > self.size:
             return k * 2
-        elif self.heap[k*2][0] < self.heap[k*2+1][0]:
+        elif self.heap[k * 2][0] <= self.heap[k * 2 + 1][0]:
             return k * 2
         else:
             return k * 2 + 1
@@ -38,10 +40,9 @@ class PriorityQueueHeap:
         return item
 
 
-
-h = PriorityQueueHeap() 
-h.insert(2, "Bat") 
-h.insert(13,"Cat")
+h = PriorityQueueHeap()
+h.insert(2, "Bat")
+h.insert(13, "Cat")
 h.insert(18, "Rat")
 h.insert(26, "Ant")
 h.insert(3, "Lion")
@@ -54,6 +55,3 @@ for i in range(h.size):
     n = h.delete_at_root()
     print(n)
     print(h.heap)
-
-
-    


### PR DESCRIPTION
Currently FIFO is not working correct.

In the following example `"Ant"` should come before `"Lion"`:

```python
>>> h = PriorityQueueHeap()
>>> h.insert(2, "Bat")
>>> h.insert(2, "Cat")
>>> h.insert(18, "Rat")
>>> h.insert(2, "Ant")
>>> h.insert(2, "Lion")
>>> h.insert(4, "Bear")
>>> 
>>> for i in range(h.size):
...     n = h.delete_at_root()
...     print(n)
... 
Bat
Cat
Lion
Ant
Bear
Rat
>>> 
```
The proposed change will fix this issue.

I also (just like #13) terminated the iteration as soon as we find out that there is no need to swap the values.